### PR TITLE
store the Hades Host URL as metadata for now

### DIFF
--- a/benchmarkController/benchmark-controller.go
+++ b/benchmarkController/benchmark-controller.go
@@ -54,10 +54,12 @@ func (b Benchmark) HandleFunc(c *gin.Context) {
 		commitHash = &hash
 	}
 
+	hadesHost := c.Query("host")
+
 	// Run the benchmark
 	slog.Debug("Running jobs", slog.Any("count", count))
 	b.JobCounter = count
-	if err := b.run(restPayload, commitHash); err != nil {
+	if err := b.run(restPayload, hadesHost, commitHash); err != nil {
 		c.JSON(400, gin.H{"message": "Benchmark failed", "error": err.Error()})
 	} else {
 		c.JSON(200, gin.H{"message": "Benchmark started"})
@@ -71,7 +73,7 @@ func (b Benchmark) HandleFunc(c *gin.Context) {
 // The function logs various stages of job execution, including the start of job
 // scheduling, any errors encountered during execution, and the successful storage
 // of job results.
-func (b Benchmark) run(payload payload.RESTPayload, commitHash *string) error {
+func (b Benchmark) run(payload payload.RESTPayload, metaData string, commitHash *string) error {
 	slog.Info("Running jobs", slog.Any("number", b.JobCounter), slog.Any("executor", b.Executor))
 	var wg sync.WaitGroup
 	var runErr error
@@ -96,7 +98,7 @@ func (b Benchmark) run(payload payload.RESTPayload, commitHash *string) error {
 
 			// Store the job
 			slog.Debug("Storing job", slog.Any("uuid", uuid))
-			p.StoreJob(uuid, time.Now(), b.Executor.Name(), commitHash)
+			p.StoreJob(uuid, time.Now(), b.Executor.Name(), metaData, commitHash)
 
 			slog.Debug("Job stored successfully", slog.Any("uuid", uuid))
 		}(b.Persister, i)

--- a/benchmarkController/benchmark-controller.go
+++ b/benchmarkController/benchmark-controller.go
@@ -55,7 +55,7 @@ func (b Benchmark) HandleFunc(c *gin.Context) {
 	}
 
 	var hadesHost *string
-	host := c.Query("hades_host")
+	host := c.Query("host")
 	if host != "" {
 		hadesHost = &host
 	}

--- a/benchmarkController/benchmark-controller.go
+++ b/benchmarkController/benchmark-controller.go
@@ -55,7 +55,7 @@ func (b Benchmark) HandleFunc(c *gin.Context) {
 	}
 
 	var hadesHost *string
-	host := c.Query("commit_hash")
+	host := c.Query("hades_host")
 	if host != "" {
 		hadesHost = &host
 	}

--- a/benchmarkController/benchmark-controller.go
+++ b/benchmarkController/benchmark-controller.go
@@ -54,7 +54,11 @@ func (b Benchmark) HandleFunc(c *gin.Context) {
 		commitHash = &hash
 	}
 
-	hadesHost := c.Query("host")
+	var hadesHost *string
+	host := c.Query("commit_hash")
+	if host != "" {
+		hadesHost = &host
+	}
 
 	// Run the benchmark
 	slog.Debug("Running jobs", slog.Any("count", count))
@@ -73,7 +77,7 @@ func (b Benchmark) HandleFunc(c *gin.Context) {
 // The function logs various stages of job execution, including the start of job
 // scheduling, any errors encountered during execution, and the successful storage
 // of job results.
-func (b Benchmark) run(payload payload.RESTPayload, metaData string, commitHash *string) error {
+func (b Benchmark) run(payload payload.RESTPayload, metaData *string, commitHash *string) error {
 	slog.Info("Running jobs", slog.Any("number", b.JobCounter), slog.Any("executor", b.Executor))
 	var wg sync.WaitGroup
 	var runErr error

--- a/bruno/CI-Benchmark/Schedule Jobs (Hades).bru
+++ b/bruno/CI-Benchmark/Schedule Jobs (Hades).bru
@@ -11,8 +11,9 @@ post {
 }
 
 params:query {
-  count: 50
+  count: 1
   commit_hash: 123456
+  host: http://localhost:8081/build
 }
 
 body:json {

--- a/bruno/CI-Benchmark/environments/local.bru
+++ b/bruno/CI-Benchmark/environments/local.bru
@@ -1,3 +1,0 @@
-vars {
-  hostname: hades-benchmarker.wei-tech.site
-}

--- a/persister/persister.go
+++ b/persister/persister.go
@@ -19,7 +19,7 @@ const file string = "benchmark.db"
 // This interface is used to store the job and the result of the job
 // This implementation allows to abstract the concrete storage mechanism
 type Persister interface {
-	StoreJob(uuid uuid.UUID, creationTime time.Time, executor string, commitHash *string)
+	StoreJob(uuid uuid.UUID, creationTime time.Time, executor string, metaData string, commitHash *string)
 	StoreStartTime(uuid uuid.UUID, startTime time.Time)
 	StoreResult(uuid uuid.UUID, time time.Time)
 }
@@ -58,19 +58,29 @@ func NewDBPersister() DBPersister {
 	}
 }
 
-func (d DBPersister) StoreJob(uuid uuid.UUID, creationTime time.Time, executor string, commitHash *string) {
+func (d DBPersister) StoreJob(uuid uuid.UUID, creationTime time.Time, executor string, metaData string, commitHash *string) {
 	var nullableHash sql.NullString
 	if commitHash != nil {
 		nullableHash = sql.NullString{String: *commitHash, Valid: true}
 	} else {
 		nullableHash = sql.NullString{Valid: false}
 	}
-	d.queries.StoreScheduledJob(context.Background(), model.StoreScheduledJobParams{
-		ID:           uuid,
-		CreationTime: creationTime.UTC(),
-		Executor:     executor,
-		CommitHash:   nullableHash,
-	})
+	if metaData != "" {
+		d.queries.StoreScheduledJobWithMetadata(context.Background(), model.StoreScheduledJobWithMetadataParams{
+			ID:           uuid,
+			CreationTime: creationTime.UTC(),
+			Executor:     executor,
+			Metadata:     metaData,
+			CommitHash:   nullableHash,
+		})
+	} else {
+		d.queries.StoreScheduledJob(context.Background(), model.StoreScheduledJobParams{
+			ID:           uuid,
+			CreationTime: creationTime.UTC(),
+			Executor:     executor,
+			CommitHash:   nullableHash,
+		})
+	}
 }
 
 func (d DBPersister) StoreStartTime(uuid uuid.UUID, startTime time.Time) {

--- a/persister/persister.go
+++ b/persister/persister.go
@@ -80,7 +80,7 @@ func (d DBPersister) StoreJob(uuid uuid.UUID, creationTime time.Time, executor s
 		ID:           uuid,
 		CreationTime: creationTime.UTC(),
 		Executor:     executor,
-		Metadata:     nullableMeta.String,
+		Metadata:     nullableMeta,
 		CommitHash:   nullableHash,
 	})
 }

--- a/persister/persister.go
+++ b/persister/persister.go
@@ -65,28 +65,24 @@ func (d DBPersister) StoreJob(uuid uuid.UUID, creationTime time.Time, executor s
 	} else {
 		nullableHash = sql.NullString{Valid: false}
 	}
-	var nullableMeta sql.NullString
-	if metaData != nil {
-		nullableMeta = sql.NullString{String: *metaData, Valid: true}
-	} else {
-		nullableMeta = sql.NullString{Valid: false}
+
+	nullableMeta := sql.NullString{
+		String: func() string {
+			if metaData != nil {
+				return *metaData
+			}
+			return ""
+		}(),
+		Valid: metaData != nil,
 	}
-	if metaData != nil {
-		d.queries.StoreScheduledJobWithMetadata(context.Background(), model.StoreScheduledJobWithMetadataParams{
-			ID:           uuid,
-			CreationTime: creationTime.UTC(),
-			Executor:     executor,
-			Metadata:     nullableMeta.String,
-			CommitHash:   nullableHash,
-		})
-	} else {
-		d.queries.StoreScheduledJob(context.Background(), model.StoreScheduledJobParams{
-			ID:           uuid,
-			CreationTime: creationTime.UTC(),
-			Executor:     executor,
-			CommitHash:   nullableHash,
-		})
-	}
+
+	d.queries.StoreScheduledJobWithMetadata(context.Background(), model.StoreScheduledJobWithMetadataParams{
+		ID:           uuid,
+		CreationTime: creationTime.UTC(),
+		Executor:     executor,
+		Metadata:     nullableMeta.String,
+		CommitHash:   nullableHash,
+	})
 }
 
 func (d DBPersister) StoreStartTime(uuid uuid.UUID, startTime time.Time) {

--- a/persister/persister.go
+++ b/persister/persister.go
@@ -58,19 +58,25 @@ func NewDBPersister() DBPersister {
 	}
 }
 
-func (d DBPersister) StoreJob(uuid uuid.UUID, creationTime time.Time, executor string, metaData string, commitHash *string) {
+func (d DBPersister) StoreJob(uuid uuid.UUID, creationTime time.Time, executor string, metaData *string, commitHash *string) {
 	var nullableHash sql.NullString
 	if commitHash != nil {
 		nullableHash = sql.NullString{String: *commitHash, Valid: true}
 	} else {
 		nullableHash = sql.NullString{Valid: false}
 	}
-	if metaData != "" {
+	var nullableMeta sql.NullString
+	if metaData != nil {
+		nullableMeta = sql.NullString{String: *metaData, Valid: true}
+	} else {
+		nullableMeta = sql.NullString{Valid: false}
+	}
+	if metaData != nil {
 		d.queries.StoreScheduledJobWithMetadata(context.Background(), model.StoreScheduledJobWithMetadataParams{
 			ID:           uuid,
 			CreationTime: creationTime.UTC(),
 			Executor:     executor,
-			Metadata:     metaData,
+			Metadata:     nullableMeta.String,
 			CommitHash:   nullableHash,
 		})
 	} else {

--- a/persister/persister.go
+++ b/persister/persister.go
@@ -19,7 +19,7 @@ const file string = "benchmark.db"
 // This interface is used to store the job and the result of the job
 // This implementation allows to abstract the concrete storage mechanism
 type Persister interface {
-	StoreJob(uuid uuid.UUID, creationTime time.Time, executor string, metaData string, commitHash *string)
+	StoreJob(uuid uuid.UUID, creationTime time.Time, executor string, metaData *string, commitHash *string)
 	StoreStartTime(uuid uuid.UUID, startTime time.Time)
 	StoreResult(uuid uuid.UUID, time time.Time)
 }


### PR DESCRIPTION
We now store the URL in the metadata to indicate which Hades instance we are using