### PR TITLE
Inject UUID into Payload Metadata for Jenkins Executors

### DIFF
--- a/executor/jenkins-executor.go
+++ b/executor/jenkins-executor.go
@@ -130,9 +130,9 @@ func (e *JenkinsExecutor) Execute(jobPayload payload.RESTPayload) (uuid.UUID, er
 	defer resp.Body.Close()
 
 	// Validate Jenkins response
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
-		slog.Debug("JenkinsExecutor returned non-201/202 status code", slog.Int("status", resp.StatusCode))
-		return jobUUID, errors.New("JenkinsExecutor returned non-201/202 status code")
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		slog.Debug("JenkinsExecutor returned non-200/201/202 status code", slog.Int("status", resp.StatusCode))
+		return jobUUID, errors.New("JenkinsExecutor returned non-200/201/202 status code")
 	}
 
 	return jobUUID, nil

--- a/executor/jenkins-executor.go
+++ b/executor/jenkins-executor.go
@@ -44,72 +44,80 @@ func (e *JenkinsExecutor) Name() string {
 func (e *JenkinsExecutor) Execute(jobPayload payload.RESTPayload) (uuid.UUID, error) {
 	slog.Debug("Executing JenkinsExecutor")
 
+	// Create UUID for this benchmark job
+	jobUUID := uuid.New()
+
+	// Inject UUID into payload metadata
+	if jobPayload.Metadata == nil {
+		jobPayload.Metadata = make(map[string]string)
+	}
+	jobPayload.Metadata["UUID"] = jobUUID.String()
+
+	slog.Info("Assigned UUID to jobPayload", slog.String("uuid", jobUUID.String()))
+
+	// Validate Jenkins config
 	if e.JenkinsURL == "" || e.User == "" || e.APIToken == "" || e.JobPath == "" {
 		slog.Debug("JenkinsExecutor not configured properly")
-		return uuid.UUID{}, errors.New("JenkinsExecutor not configured: need JenkinsURL, User, APIToken, JobPath")
+		return jobUUID, errors.New("JenkinsExecutor not configured: need JenkinsURL, User, APIToken, JobPath")
 	}
 
+	// Get Jenkins crumb
 	crumbField, crumbValue, err := e.getCrumb()
 	if err != nil {
 		slog.Debug("Error while getting Jenkins crumb")
-		return uuid.UUID{}, err
+		return jobUUID, err
 	}
 
 	var endpoint string
 	var req *http.Request
 
+	// Build request
 	if e.UseParameters {
 		params, err := e.payloadToParams(jobPayload)
+		// NOTE: params now contain the UUID inside HADES_PAYLOAD_JSON
 		if err != nil {
 			slog.Debug("Error while serializing payload")
-			return uuid.UUID{}, err
+			return jobUUID, err
 		}
-		endpoint = e.JenkinsURL + "/" + strings.TrimLeft(e.JobPath, "/") + "/buildWithParameters"
 
+		endpoint = e.JenkinsURL + "/" + strings.TrimLeft(e.JobPath, "/") + "/buildWithParameters"
 		req, err = http.NewRequest(http.MethodPost, endpoint, strings.NewReader(params.Encode()))
 		if err != nil {
 			slog.Debug("Error while creating POST request to Jenkins (parameters)")
-			return uuid.UUID{}, err
+			return jobUUID, err
 		}
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
 	} else {
 		endpoint = e.JenkinsURL + "/" + strings.TrimLeft(e.JobPath, "/") + "/build"
-
-		var err error
 		req, err = http.NewRequest(http.MethodPost, endpoint, nil)
 		if err != nil {
 			slog.Debug("Error while creating POST request to Jenkins (no parameters)")
-			return uuid.UUID{}, err
+			return jobUUID, err
 		}
 	}
 
+	// Set auth & crumb
 	req.SetBasicAuth(e.User, e.APIToken)
 	if crumbField != "" && crumbValue != "" {
 		req.Header.Set(crumbField, crumbValue)
 	}
 
+	// Send request
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		slog.Debug("Error while sending POST request to Jenkins")
-		return uuid.UUID{}, err
+		return jobUUID, err
 	}
 	defer resp.Body.Close()
 
+	// Validate Jenkins response
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
 		slog.Debug("JenkinsExecutor returned non-201/202 status code", slog.Int("status", resp.StatusCode))
-		return uuid.UUID{}, errors.New("JenkinsExecutor returned non-201/202 status code")
+		return jobUUID, errors.New("JenkinsExecutor returned non-201/202 status code")
 	}
 
-	loc := strings.TrimSpace(resp.Header.Get("Location"))
-	if loc == "" {
-		slog.Debug("JenkinsExecutor missing Location header")
-		return uuid.UUID{}, errors.New("JenkinsExecutor response missing Location header (queue item url)")
-	}
-
-	id := uuid.NewSHA1(uuid.NameSpaceURL, []byte(strings.TrimRight(loc, "/")))
-	slog.Info("JenkinsExecutor queued successfully", slog.String("queue_url", loc), slog.Any("jobID", id))
-
-	return id, nil
+	return jobUUID, nil
 }
 
 func (e *JenkinsExecutor) getCrumb() (field string, value string, err error) {
@@ -140,20 +148,11 @@ func (e *JenkinsExecutor) getCrumb() (field string, value string, err error) {
 }
 
 func (e *JenkinsExecutor) payloadToParams(p payload.RESTPayload) (url.Values, error) {
-	if p.Metadata == nil {
-		p.Metadata = make(map[string]string)
-	}
-
-	jenkinsID := uuid.New().String()
-	p.Metadata["jenkinsId"] = jenkinsID
-
+	values := url.Values{}
 	b, err := json.Marshal(p)
 	if err != nil {
 		return nil, err
 	}
-
-	values := url.Values{}
 	values.Set("HADES_PAYLOAD_JSON", string(b))
-
 	return values, nil
 }

--- a/executor/jenkins-executor.go
+++ b/executor/jenkins-executor.go
@@ -140,11 +140,20 @@ func (e *JenkinsExecutor) getCrumb() (field string, value string, err error) {
 }
 
 func (e *JenkinsExecutor) payloadToParams(p payload.RESTPayload) (url.Values, error) {
-	values := url.Values{}
+	if p.Metadata == nil {
+		p.Metadata = make(map[string]string)
+	}
+
+	jenkinsID := uuid.New().String()
+	p.Metadata["jenkinsId"] = jenkinsID
+
 	b, err := json.Marshal(p)
 	if err != nil {
 		return nil, err
 	}
+
+	values := url.Values{}
 	values.Set("HADES_PAYLOAD_JSON", string(b))
+
 	return values, nil
 }

--- a/executor/jenkins-executor.go
+++ b/executor/jenkins-executor.go
@@ -150,11 +150,20 @@ func (e *JenkinsExecutor) getCrumb() (field string, value string, err error) {
 }
 
 func (e *JenkinsExecutor) payloadToParams(p payload.RESTPayload) (url.Values, error) {
-	values := url.Values{}
+	if p.Metadata == nil {
+		p.Metadata = make(map[string]string)
+	}
+
+	jenkinsID := uuid.New().String()
+	p.Metadata["jenkinsId"] = jenkinsID
+
 	b, err := json.Marshal(p)
 	if err != nil {
 		return nil, err
 	}
+
+	values := url.Values{}
 	values.Set("HADES_PAYLOAD_JSON", string(b))
+
 	return values, nil
 }

--- a/executor/jenkins-executor.go
+++ b/executor/jenkins-executor.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/ls1intum/hades/shared/payload"
@@ -21,11 +23,25 @@ type JenkinsExecutor struct {
 	APIToken      string
 	JobPath       string
 	UseParameters bool
+
+	crumbField  string
+	crumbValue  string
+	crumbExpiry time.Time
+	crumbMu     sync.Mutex
 }
 
 type crumbResp struct {
 	Crumb             string `json:"crumb"`
 	CrumbRequestField string `json:"crumbRequestField"`
+}
+
+var jenkinsClient = &http.Client{
+	Timeout: 10 * time.Second,
+	Transport: &http.Transport{
+		MaxIdleConns:        100,
+		MaxConnsPerHost:     100,
+		MaxIdleConnsPerHost: 100,
+	},
 }
 
 func NewJenkinsExecutor(jenkinsURL string, user string, APIToken string, path string, useParameters bool) *JenkinsExecutor {
@@ -106,7 +122,7 @@ func (e *JenkinsExecutor) Execute(jobPayload payload.RESTPayload) (uuid.UUID, er
 	}
 
 	// Send request
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := jenkinsClient.Do(req)
 	if err != nil {
 		slog.Debug("Error while sending POST request to Jenkins")
 		return jobUUID, err
@@ -123,21 +139,54 @@ func (e *JenkinsExecutor) Execute(jobPayload payload.RESTPayload) (uuid.UUID, er
 }
 
 func (e *JenkinsExecutor) getCrumb() (field string, value string, err error) {
+
+	now := time.Now()
+
+	// -----------------------------
+	// First quick check (no lock)
+	// -----------------------------
+	if e.crumbField != "" && now.Before(e.crumbExpiry) {
+		return e.crumbField, e.crumbValue, nil
+	}
+
+	// -----------------------------
+	// Acquire lock for refresh
+	// -----------------------------
+	e.crumbMu.Lock()
+	defer e.crumbMu.Unlock()
+
+	// -----------------------------
+	// Double-check after locking
+	// -----------------------------
+	if e.crumbField != "" && now.Before(e.crumbExpiry) {
+		return e.crumbField, e.crumbValue, nil
+	}
+
+	// -----------------------------
+	// Actually fetch new crumb
+	// -----------------------------
+	slog.Info("Fetching new Jenkins crumb...")
+
 	req, err := http.NewRequest(http.MethodGet, e.JenkinsURL+"/crumbIssuer/api/json", nil)
 	if err != nil {
 		return "", "", err
 	}
 	req.SetBasicAuth(e.User, e.APIToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := jenkinsClient.Do(req)
 	if err != nil {
 		return "", "", err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
+		// Jenkins has crumb disabled
+		e.crumbField = ""
+		e.crumbValue = ""
+		e.crumbExpiry = now.Add(30 * time.Minute) // arbitrary good TTL
 		return "", "", nil
 	}
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", "", errors.New("failed to get Jenkins crumb")
 	}
@@ -146,7 +195,17 @@ func (e *JenkinsExecutor) getCrumb() (field string, value string, err error) {
 	if err := json.NewDecoder(resp.Body).Decode(&c); err != nil {
 		return "", "", err
 	}
-	return c.CrumbRequestField, c.Crumb, nil
+
+	// -----------------------------
+	// Save to cache with TTL
+	// -----------------------------
+	e.crumbField = c.CrumbRequestField
+	e.crumbValue = c.Crumb
+	e.crumbExpiry = now.Add(45 * time.Minute) // safer than 1h, Jenkins default
+
+	slog.Info("Fetched new crumb", "expires_at", e.crumbExpiry.String())
+
+	return e.crumbField, e.crumbValue, nil
 }
 
 func (e *JenkinsExecutor) payloadToParams(p payload.RESTPayload) (url.Values, error) {

--- a/executor/jenkins-executor.go
+++ b/executor/jenkins-executor.go
@@ -64,14 +64,9 @@ func (e *JenkinsExecutor) Execute(jobPayload payload.RESTPayload) (uuid.UUID, er
 
 	// Create UUID for this benchmark job
 	jobUUID := uuid.New()
+	jobPayload.QueuePayload.ID = jobUUID
 
-	// Inject UUID into payload metadata
-	if jobPayload.Metadata == nil {
-		jobPayload.Metadata = make(map[string]string)
-	}
-	jobPayload.Metadata["UUID"] = jobUUID.String()
-
-	slog.Info("Assigned UUID to jobPayload", slog.String("uuid", jobUUID.String()))
+	slog.Debug("UUID generated:", slog.String("uuid", jobUUID.String()))
 
 	// Validate Jenkins config
 	if e.JenkinsURL == "" || e.User == "" || e.APIToken == "" || e.JobPath == "" {
@@ -92,7 +87,6 @@ func (e *JenkinsExecutor) Execute(jobPayload payload.RESTPayload) (uuid.UUID, er
 	// Build request
 	if e.UseParameters {
 		params, err := e.payloadToParams(jobPayload)
-		// NOTE: params now contain the UUID inside HADES_PAYLOAD_JSON
 		if err != nil {
 			slog.Debug("Error while serializing payload")
 			return jobUUID, err
@@ -130,9 +124,9 @@ func (e *JenkinsExecutor) Execute(jobPayload payload.RESTPayload) (uuid.UUID, er
 	defer resp.Body.Close()
 
 	// Validate Jenkins response
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
-		slog.Debug("JenkinsExecutor returned non-200/201/202 status code", slog.Int("status", resp.StatusCode))
-		return jobUUID, errors.New("JenkinsExecutor returned non-200/201/202 status code")
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
+		slog.Debug("JenkinsExecutor returned non-201/202 status code", slog.Int("status", resp.StatusCode))
+		return jobUUID, errors.New("JenkinsExecutor returned non-201/202 status code")
 	}
 
 	return jobUUID, nil
@@ -213,9 +207,6 @@ func (e *JenkinsExecutor) payloadToParams(p payload.RESTPayload) (url.Values, er
 		p.Metadata = make(map[string]string)
 	}
 
-	jenkinsID := uuid.New().String()
-	p.Metadata["jenkinsId"] = jenkinsID
-
 	b, err := json.Marshal(p)
 	if err != nil {
 		return nil, err
@@ -223,6 +214,7 @@ func (e *JenkinsExecutor) payloadToParams(p payload.RESTPayload) (url.Values, er
 
 	values := url.Values{}
 	values.Set("HADES_PAYLOAD_JSON", string(b))
+	values.Set("HADES_UUID", p.ID.String())
 
 	return values, nil
 }


### PR DESCRIPTION
### Background

In Hades Docker mode, the executor container receives job metadata (including UUID) through environment variables mounted from the shared volume.
However, in Jenkins mode, executor containers do not inherit these environment variables. This leads to two major issues:

**1. Jenkins builds cannot report UUID to CI-Benchmarker**

Because Jenkins executors do not receive UUID from the environment, they cannot include it when reporting:

- Build start time
- Build completion result

The CI-Benchmarker API then returns:

> **400 Bad Request – missing UUID**

This prevents events from being correlated and breaks the benchmark workflow.

**2. Jenkins may ignore builds when payloads are identical**

Jenkins applies optimization logic:
When the incoming build parameters (payload) are identical to the previous build, Jenkins will skip triggering a new run.

This is problematic during large-scale benchmarking — thousands of builds may share the same payload, causing Jenkins to treat them as duplicates and not start new builds.

Adding a unique uuid field ensures that every Jenkins build request is unique, making reliable high-volume benchmarking possible.

### What This PR Changes

This PR injects a unique UUID into the payload metadata before triggering a Jenkins build, e.g.:

```
"metadata": {
  "uuid": "<job-uuid>"
}
```

### Effects

Jenkins executors always receive a UUID through payload → can report correctly to CI-Benchmarker.

CI-Benchmarker no longer returns 400 due to missing UUID.

Jenkins will always treat each build as unique and will not skip builds with identical payloads.

Docker mode remains unchanged and fully compatible.