### PR TITLE
Hygiene and correctness: CI checks, RFC3339 parsing, connection leak, durable deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,26 @@
+# --- Local runs only (`go run .`) -------------------------------------------
+# docker-compose.yml sets both of these itself and ignores what is set here:
+# the port has to agree with the `expose` entry and the Traefik loadbalancer
+# label, and DB_PATH has to point inside the benchmark-data volume.
+
 # Port the benchmarker listens on.
 SERVER_ADDRESS=8080
 
-# Where the benchmark database lives. In docker-compose this points into the
-# benchmark-data volume so a --force-recreate cannot destroy a dataset.
+# Where the benchmark database lives.
 DB_PATH=benchmark.db
+
+# --- docker compose ----------------------------------------------------------
 
 # Hostname Traefik routes to. Previously hardcoded in docker-compose.yml.
 BENCHMARKER_HOST=ci-benchmarker.example.org
 
-# Image tag to run. Pin to a release for a measurement campaign.
-BENCHMARKER_IMAGE_TAG=latest
+# Image tag to run. Required - docker compose refuses to start without it.
+# Use an immutable release or commit tag so the collected data records which
+# build produced it. `latest` moves, and must not be used for a campaign.
+BENCHMARKER_IMAGE_TAG=v0.1.0
 
 LETSENCRYPT_EMAIL=example@tum.de
+
+# --- both --------------------------------------------------------------------
 
 DEBUG=false

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,16 @@
+# Port the benchmarker listens on.
 SERVER_ADDRESS=8080
+
+# Where the benchmark database lives. In docker-compose this points into the
+# benchmark-data volume so a --force-recreate cannot destroy a dataset.
+DB_PATH=benchmark.db
+
+# Hostname Traefik routes to. Previously hardcoded in docker-compose.yml.
+BENCHMARKER_HOST=ci-benchmarker.example.org
+
+# Image tag to run. Pin to a release for a measurement campaign.
+BENCHMARKER_IMAGE_TAG=latest
+
 LETSENCRYPT_EMAIL=example@tum.de
+
+DEBUG=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Docker Images
+name: Build
 
 on:
   pull_request:
@@ -14,8 +14,44 @@ on:
       - created
 
 jobs:
+  # Gate the image build on the tests. This is a measurement instrument: an
+  # image that fails its own idempotency or timing tests must not be publishable.
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: true
+
+    - name: Verify formatting
+      run: |
+        unformatted=$(gofmt -l .)
+        if [ -n "$unformatted" ]; then
+          echo "These files are not gofmt-formatted:"
+          echo "$unformatted"
+          exit 1
+        fi
+
+    - name: go vet
+      run: go vet ./...
+
+    # CGO is required for the SQLite driver.
+    - name: go test
+      env:
+        CGO_ENABLED: 1
+      run: go test -race -timeout 15m ./...
+
   build:
     runs-on: ubuntu-latest
+    needs: test
 
     permissions:
       contents: read
@@ -56,6 +92,8 @@ jobs:
         context: .
         push: true
         platforms: linux/amd64,linux/arm64
+        build-args: |
+          VERSION=${{ github.sha }}
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Logout from GitHub Container Registry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,10 @@
 name: Build
 
 on:
+  # No branch filter: a pull request stacked on another feature branch must
+  # still be tested. Restricting this to main meant a stacked PR ran no checks
+  # at all.
   pull_request:
-    branches:
-      - main
-      - release/*
   push:
     branches:
         - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ on:
     types:
       - created
 
+# Read-only by default. The build job escalates to `packages: write` for itself,
+# so the test job cannot push anything even if a dependency misbehaves.
+permissions:
+  contents: read
+
 jobs:
   # Gate the image build on the tests. This is a measurement instrument: an
   # image that fails its own idempotency or timing tests must not be publishable.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,15 @@ RUN go mod download
 
 COPY . .
 
+# Stamped into the binary so a running deployment can state which build it is.
+# The CI workflow passes the commit SHA.
+ARG VERSION=dev
+
 ENV CGO_ENABLED=1
 
-RUN go build -o /out/benchmarker .
+RUN go build \
+    -ldflags "-X github.com/Hades-Scheduler/CI-Benchmarker/shared/config.Version=${VERSION}" \
+    -o /out/benchmarker .
 
 FROM alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,33 @@
-# Use an official Go runtime as a parent image
 FROM golang:1.26-alpine AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
-# Set the working directory inside the container
 WORKDIR /app
 
-# Copy files and download dependencies
-COPY . . 
+# Dependencies in their own layer so a source-only change does not re-download
+# the whole module graph.
+COPY go.mod go.sum ./
 RUN go mod download
 
+COPY . .
 
-# Build the Go application
 ENV CGO_ENABLED=1
 
-RUN go build -o benchmarker .
+RUN go build -o /out/benchmarker .
 
-# Start a new stage for the runtime container
 FROM alpine
 
-# Set the working directory inside the minimal runtime container
+# Needed to reach systems under test over HTTPS and to interpret timestamps.
+RUN apk add --no-cache ca-certificates tzdata
+
 WORKDIR /app
 
-# Copy the built binary from the builder container into the minimal runtime container
-COPY --from=builder /app . 
+# Copy only the binary. The previous image copied the entire build context,
+# including sources and the .git-derived build tree.
+COPY --from=builder /out/benchmarker /app/benchmarker
 
-# Run your Go application
+# The database lives on a volume; see docker-compose.yml.
+ENV DB_PATH=/data/benchmark.db
+VOLUME /data
+
 CMD ["/app/benchmarker"]

--- a/README.md
+++ b/README.md
@@ -7,16 +7,18 @@
 ## Usage
 
 ```bash
-cp .env.example .env      # set BENCHMARKER_HOST at least
+cp .env.example .env      # set BENCHMARKER_HOST and BENCHMARKER_IMAGE_TAG
 docker compose up -d
 ```
 
 The database lives in the `benchmark-data` volume rather than in the container
 filesystem, so `--force-recreate` cannot destroy a collected dataset. The
-compose file runs the pinned image; there is deliberately no `build: .`, so a
+compose file runs a pinned image; there is deliberately no `build: .`, so a
 redeploy cannot silently swap in whatever is in the working tree.
+`BENCHMARKER_IMAGE_TAG` has no default and compose refuses to start without it,
+so a campaign cannot accidentally run a moving `latest`.
 
-Use the [bruno](https://www.usebruno.com/) examples in the `bruno` folder to test the system
+Use the [Bruno](https://www.usebruno.com/) examples in [`bruno/`](./bruno) to test the system
 
 ## Development
 
@@ -28,13 +30,14 @@ Start in dev mode
 
 ### Checks
 
-```bash
-gofmt -l .
-go vet ./...
-go test ./...
-```
+These are exactly what CI runs; the image build is gated on them passing.
 
-CI runs all three, and the image build is gated on them passing.
+```bash
+unformatted=$(gofmt -l .)
+test -z "$unformatted"
+go vet ./...
+CGO_ENABLED=1 go test -race -timeout 15m ./...
+```
 
 ### Generate Open API spec
 Install swag by using:

--- a/README.md
+++ b/README.md
@@ -7,18 +7,34 @@
 ## Usage
 
 ```bash
-  docker-compose up
+cp .env.example .env      # set BENCHMARKER_HOST at least
+docker compose up -d
 ```
 
-Use the [bruno](https://www.usebruno.com/) examples in the `docs` folder to test the system
+The database lives in the `benchmark-data` volume rather than in the container
+filesystem, so `--force-recreate` cannot destroy a collected dataset. The
+compose file runs the pinned image; there is deliberately no `build: .`, so a
+redeploy cannot silently swap in whatever is in the working tree.
+
+Use the [bruno](https://www.usebruno.com/) examples in the `bruno` folder to test the system
 
 ## Development
 
 Start in dev mode
 
 ```bash
-  DEBUG=True go run .
+  DEBUG=true go run .
 ```
+
+### Checks
+
+```bash
+gofmt -l .
+go vet ./...
+go test ./...
+```
+
+CI runs all three, and the image build is gated on them passing.
 
 ### Generate Open API spec
 Install swag by using:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,17 +16,23 @@ services:
 
   benchmarker:
     # No `build: .` - the pinned image is what runs, so a redeploy cannot
-    # silently swap in whatever happens to be in the working tree. Pin
-    # BENCHMARKER_IMAGE_TAG to a release for a measurement campaign.
-    image: ghcr.io/hades-scheduler/ci-benchmarker/benchmarker:${BENCHMARKER_IMAGE_TAG:-latest}
+    # silently swap in whatever happens to be in the working tree. There is
+    # deliberately no default: a `latest` fallback would let a redeploy change
+    # the instrument mid-campaign, which is the failure this line exists to
+    # prevent. Set BENCHMARKER_IMAGE_TAG to a release or commit tag.
+    image: ghcr.io/hades-scheduler/ci-benchmarker/benchmarker:${BENCHMARKER_IMAGE_TAG:?set BENCHMARKER_IMAGE_TAG to an immutable release or commit tag}
     container_name: benchmarker
     expose:
       - "8080"
     environment:
+      # Fixed, not taken from .env: the port also appears in `expose` and in the
+      # Traefik loadbalancer label, and a partial override would silently break
+      # routing.
       - SERVER_ADDRESS=8080
-      # Inside the volume, so `docker compose up --force-recreate` cannot
-      # destroy a dataset. This is a measurement instrument; the database is
-      # the result.
+      # Fixed, not taken from .env: this must point inside the volume, so that
+      # `docker compose up --force-recreate` cannot destroy a dataset. This is a
+      # measurement instrument; the database is the result. Mount the volume
+      # elsewhere rather than pointing DB_PATH out of it.
       - DB_PATH=/data/benchmark.db
       - DEBUG=${DEBUG:-false}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   traefik:
     image: traefik:v3.0
@@ -17,16 +15,31 @@ services:
     restart: always
 
   benchmarker:
-    build: .
-    image: ghcr.io/hades-scheduler/ci-benchmarker/benchmarker:latest
+    # No `build: .` - the pinned image is what runs, so a redeploy cannot
+    # silently swap in whatever happens to be in the working tree. Pin
+    # BENCHMARKER_IMAGE_TAG to a release for a measurement campaign.
+    image: ghcr.io/hades-scheduler/ci-benchmarker/benchmarker:${BENCHMARKER_IMAGE_TAG:-latest}
     container_name: benchmarker
     expose:
       - "8080"
     environment:
       - SERVER_ADDRESS=8080
+      # Inside the volume, so `docker compose up --force-recreate` cannot
+      # destroy a dataset. This is a measurement instrument; the database is
+      # the result.
+      - DB_PATH=/data/benchmark.db
+      - DEBUG=${DEBUG:-false}
+    volumes:
+      - benchmark-data:/data
+    restart: always
     labels:
       - traefik.enable=true
-      - traefik.http.routers.benchmarker.rule=Host(`ma-yu.aet.cit.tum.de`)
+      # Was hardcoded to a single TUM hostname, which made the compose file
+      # unusable for anyone else and undeployable to a second load generator.
+      - traefik.http.routers.benchmarker.rule=Host(`${BENCHMARKER_HOST}`)
       - traefik.http.routers.benchmarker.entrypoints=web,websecure
       - traefik.http.routers.benchmarker.tls.certresolver=letsencrypt
       - traefik.http.services.benchmarker.loadbalancer.server.port=8080
+
+volumes:
+  benchmark-data:

--- a/executor/hades-executor.go
+++ b/executor/hades-executor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 
@@ -38,17 +39,24 @@ func (e *HadesExecutor) Execute(jobPayload payload.RESTPayload) (uuid.UUID, erro
 	}
 
 	// schedule job - send the http post request to hades
-	resp, err := http.Post(e.HadesURL, "application/json", bytes.NewBufferString(string(jobPayloadBytes)))
+	resp, err := http.Post(e.HadesURL, "application/json", bytes.NewReader(jobPayloadBytes))
 	if err != nil {
 		slog.Debug("Error while sending POST request to Hades")
 		return uuid.UUID{}, err
 	}
+	// Closed before any early return. The defer used to sit AFTER the non-200
+	// check, so every rejected submission leaked its response body and its
+	// connection; over a long run that degrades the load generator itself,
+	// which is the machine the measurements come from.
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+		_ = resp.Body.Close()
+	}()
+
 	if resp.StatusCode != http.StatusOK {
 		slog.Debug(fmt.Sprintf("HadesExecutor returned status code %d", resp.StatusCode))
 		return uuid.UUID{}, fmt.Errorf("HadesExecutor returned non-200 status code: %d", resp.StatusCode)
 	}
-	defer resp.Body.Close()
-	slog.Debug("HadesExecutor response", slog.Any("response", resp))
 
 	// Read the response body
 	var result struct {

--- a/executor/hades-executor_test.go
+++ b/executor/hades-executor_test.go
@@ -1,0 +1,62 @@
+package executor
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hades-scheduler/hades/shared/payload"
+)
+
+// A rejected submission must not leak its response body.
+//
+// The check is indirect but exact: a response body that is drained and closed
+// returns its connection to the idle pool, so sequential requests reuse one
+// connection. A leaked body cannot be reused, so each request opens a new one.
+func TestHadesExecutorClosesBodyOnRejection(t *testing.T) {
+	var newConnections atomic.Int64
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"queue full"}`))
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConnections.Add(1)
+		}
+	}
+	server.Start()
+	defer server.Close()
+
+	exec := NewHadesExecutor(server.URL, Docker)
+
+	const attempts = 30
+	for i := 0; i < attempts; i++ {
+		if _, err := exec.Execute(payload.RESTPayload{}); err == nil {
+			t.Fatal("expected an error for a 500 response")
+		}
+	}
+
+	if opened := newConnections.Load(); opened > 5 {
+		t.Errorf("server saw %d new connections for %d sequential rejected submissions; "+
+			"response bodies are not being returned to the pool", opened, attempts)
+	}
+}
+
+func TestHadesExecutorReturnsAcknowledgedJobID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":"queued","job_id":"6f1a5b1e-6d1a-4f5f-9d0e-1a2b3c4d5e6f"}`))
+	}))
+	defer server.Close()
+
+	jobID, err := NewHadesExecutor(server.URL, Docker).Execute(payload.RESTPayload{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if jobID.String() != "6f1a5b1e-6d1a-4f5f-9d0e-1a2b3c4d5e6f" {
+		t.Errorf("jobID = %s", jobID)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -39,6 +39,8 @@ func main() {
 
 	cfg := config.Load()
 
+	slog.Info("CI-Benchmarker starting", slog.String("version", config.Version))
+
 	slog.Debug("Creating DB persister")
 	p = persister.NewDBPersister()
 

--- a/persister/persister.go
+++ b/persister/persister.go
@@ -45,13 +45,26 @@ type DBPersister struct {
 var ddl string
 var ddlOnce sync.Once
 
-func NewDBPersister() DBPersister {
-	path := config.Load().DBPath
+// resolveDBPath falls back to DefaultDBFile when DB_PATH is unset.
+func resolveDBPath(path string) string {
 	if path == "" {
-		path = DefaultDBFile
+		return DefaultDBFile
 	}
+	return path
+}
 
-	dsn := "file:" + url.PathEscape(path) + "?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on"
+// dsnFor builds the SQLite DSN for a filesystem path. The path is
+// percent-escaped so that a `?` or `#` in it cannot truncate the URI or be
+// mistaken for a query parameter. SQLite's own URI parser decodes the escapes
+// again, so an absolute path still resolves to that absolute path - which
+// persister_test.go asserts, because getting it wrong would silently write the
+// database outside the mounted volume.
+func dsnFor(path string) string {
+	return "file:" + url.PathEscape(path) + "?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on"
+}
+
+func NewDBPersister() DBPersister {
+	dsn := dsnFor(resolveDBPath(config.Load().DBPath))
 
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {

--- a/persister/persister.go
+++ b/persister/persister.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -14,10 +15,13 @@ import (
 	"github.com/mattn/go-sqlite3"
 
 	"github.com/Hades-Scheduler/CI-Benchmarker/persister/model"
+	"github.com/Hades-Scheduler/CI-Benchmarker/shared/config"
 	"github.com/google/uuid"
 )
 
-const file string = "benchmark.db"
+// DefaultDBFile is used when DB_PATH is not set.
+const DefaultDBFile = "benchmark.db"
+
 const maxAttempts = 5
 
 // Persister interface
@@ -42,7 +46,12 @@ var ddl string
 var ddlOnce sync.Once
 
 func NewDBPersister() DBPersister {
-	dsn := "file:" + file + "?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on"
+	path := config.Load().DBPath
+	if path == "" {
+		path = DefaultDBFile
+	}
+
+	dsn := "file:" + url.PathEscape(path) + "?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on"
 
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {

--- a/persister/persister_test.go
+++ b/persister/persister_test.go
@@ -1,0 +1,65 @@
+package persister
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// The container sets DB_PATH=/data/benchmark.db, pointing at a mounted volume.
+// If the DSN ever stops resolving an absolute DB_PATH to that exact absolute
+// path, the database silently lands in the container filesystem instead and a
+// `docker compose up --force-recreate` destroys the dataset - the failure this
+// whole change exists to prevent. Assert the resolution rather than trusting it.
+func TestDSNResolvesAbsolutePathVerbatim(t *testing.T) {
+	dir := t.TempDir()
+	want := filepath.Join(dir, "benchmark.db")
+
+	db, err := sql.Open("sqlite3", dsnFor(want))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	// sql.Open is lazy; force a connection so the file is actually created.
+	if _, err := db.Exec("CREATE TABLE probe (x INTEGER)"); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("database did not land at %s: %v", want, err)
+	}
+}
+
+// A path containing characters that are structural in a URI must not truncate
+// the DSN or leak into the query parameters.
+func TestDSNEscapesPathsThatWouldBreakTheURI(t *testing.T) {
+	dir := t.TempDir()
+	want := filepath.Join(dir, "run?a=1#frag.db")
+
+	db, err := sql.Open("sqlite3", dsnFor(want))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec("CREATE TABLE probe (x INTEGER)"); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("database did not land at %s: %v", want, err)
+	}
+}
+
+func TestDefaultDBFileUsedWhenPathEmpty(t *testing.T) {
+	if got := resolveDBPath(""); got != DefaultDBFile {
+		t.Errorf("resolveDBPath(%q) = %q, want %q", "", got, DefaultDBFile)
+	}
+	if got := resolveDBPath("/data/benchmark.db"); got != "/data/benchmark.db" {
+		t.Errorf("resolveDBPath overrode an explicit path: got %q", got)
+	}
+}

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -8,6 +8,11 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Version identifies the build. Override at build time with
+// -ldflags "-X github.com/Hades-Scheduler/CI-Benchmarker/shared/config.Version=<sha>";
+// the Dockerfile does this from its VERSION build argument.
+var Version = "dev"
+
 type Config struct {
 	ServerAddress string `mapstructure:"SERVER_ADDRESS"`
 

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -10,6 +10,12 @@ import (
 
 type Config struct {
 	ServerAddress string `mapstructure:"SERVER_ADDRESS"`
+
+	// DBPath is where the benchmark database lives. It is configurable so the
+	// container can keep it on a mounted volume: the database is the result of
+	// a measurement campaign, and a `docker compose up --force-recreate` must
+	// not be able to destroy it.
+	DBPath string `mapstructure:"DB_PATH"`
 }
 
 var (
@@ -32,7 +38,11 @@ func Load() Config {
 			slog.Warn("No .env file found or failed to load it", "error", err)
 		}
 
+		viper.SetDefault("SERVER_ADDRESS", "8080")
+		viper.SetDefault("DB_PATH", "benchmark.db")
+
 		_ = viper.BindEnv("SERVER_ADDRESS")
+		_ = viper.BindEnv("DB_PATH")
 
 		if err := viper.Unmarshal(&cfg); err != nil {
 			slog.Error("Failed to unmarshal config", "error", err)

--- a/shared/utils/time_parser.go
+++ b/shared/utils/time_parser.go
@@ -1,38 +1,59 @@
 package utils
 
 import (
-	"github.com/gin-gonic/gin"
-	"log"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/gin-gonic/gin"
 )
 
-func parseTime(value string) (*time.Time, error) {
+// acceptedTimeLayouts are tried in order.
+//
+// The previous implementation accepted only "2006-01-02T15:04:05", which
+// rejects real RFC3339 (it has no offset and no fractional seconds) even though
+// every Swagger annotation on the endpoints using it promises RFC3339. Any
+// caller that followed the documentation got a 400.
+var acceptedTimeLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05.999999999",
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04:05",
+	"2006-01-02",
+}
+
+// ParseTime parses a timestamp in any accepted layout. An empty string yields
+// a nil time with no error, meaning "unbounded".
+func ParseTime(value string) (*time.Time, error) {
 	if value == "" {
 		return nil, nil
 	}
-	parsed, err := time.Parse("2006-01-02T15:04:05", value)
-	if err != nil {
-		return nil, err
+
+	for _, layout := range acceptedTimeLayouts {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return &parsed, nil
+		}
 	}
-	return &parsed, nil
+
+	return nil, fmt.Errorf("cannot parse %q; expected RFC3339, e.g. 2026-08-20T10:00:00Z", value)
 }
 
+// ParseTimeParams reads the optional from/to query parameters. It writes a 400
+// and returns false when either is unparseable.
 func ParseTimeParams(c *gin.Context) (*time.Time, *time.Time, bool) {
-	fromStr := c.Query("from")
-	toStr := c.Query("to")
-
-	from, err := parseTime(fromStr)
+	from, err := ParseTime(c.Query("from"))
 	if err != nil {
-		log.Println("Invalid 'from' parameter:", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid 'from' parameter"})
+		slog.Warn("Invalid 'from' parameter", slog.Any("error", err))
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid 'from' parameter: " + err.Error()})
 		return nil, nil, false
 	}
 
-	to, err := parseTime(toStr)
+	to, err := ParseTime(c.Query("to"))
 	if err != nil {
-		log.Println("Invalid 'to' parameter:", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid 'to' parameter"})
+		slog.Warn("Invalid 'to' parameter", slog.Any("error", err))
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid 'to' parameter: " + err.Error()})
 		return nil, nil, false
 	}
 

--- a/shared/utils/time_parser_test.go
+++ b/shared/utils/time_parser_test.go
@@ -1,0 +1,97 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+// Every endpoint using these parameters documents them as RFC3339, but the
+// parser only accepted "2006-01-02T15:04:05", which is not RFC3339: it has no
+// offset and no fractional seconds. A caller who followed the documentation got
+// a 400.
+func TestParseTimeAcceptsRFC3339(t *testing.T) {
+	cases := map[string]time.Time{
+		"2026-08-20T10:00:00Z":           time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC),
+		"2026-08-20T10:00:00.123456789Z": time.Date(2026, 8, 20, 10, 0, 0, 123456789, time.UTC),
+		"2026-08-20T12:00:00+02:00":      time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC),
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			got, err := ParseTime(input)
+			if err != nil {
+				t.Fatalf("ParseTime(%q): %v", input, err)
+			}
+			if got == nil {
+				t.Fatal("ParseTime returned nil without an error")
+			}
+			if !got.Equal(want) {
+				t.Errorf("ParseTime(%q) = %v, want %v", input, got, want)
+			}
+		})
+	}
+}
+
+// The previously accepted layouts must keep working so existing dashboards and
+// saved requests do not break.
+func TestParseTimeAcceptsLegacyLayouts(t *testing.T) {
+	for _, input := range []string{
+		"2026-08-20T10:00:00",
+		"2026-08-20 10:00:00",
+		"2026-08-20",
+	} {
+		if _, err := ParseTime(input); err != nil {
+			t.Errorf("ParseTime(%q): %v", input, err)
+		}
+	}
+}
+
+// An empty parameter means "unbounded", not "invalid".
+func TestParseTimeEmptyIsUnbounded(t *testing.T) {
+	got, err := ParseTime("")
+	if err != nil {
+		t.Fatalf("ParseTime(\"\"): %v", err)
+	}
+	if got != nil {
+		t.Errorf("ParseTime(\"\") = %v, want nil", got)
+	}
+}
+
+func TestParseTimeRejectsGarbage(t *testing.T) {
+	for _, input := range []string{"yesterday", "20/08/2026", "10:00:00"} {
+		if _, err := ParseTime(input); err == nil {
+			t.Errorf("ParseTime(%q) accepted an unparseable value", input)
+		}
+	}
+}
+
+func TestParseTimeParamsWritesBadRequest(t *testing.T) {
+	router := gin.New()
+	router.GET("/x", func(c *gin.Context) {
+		if _, _, ok := ParseTimeParams(c); ok {
+			c.Status(http.StatusOK)
+		}
+	})
+
+	t.Run("rfc3339 accepted", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/x?from=2026-08-20T10:00:00Z", nil))
+		if recorder.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200; RFC3339 is what the API documents", recorder.Code)
+		}
+	})
+
+	t.Run("garbage rejected", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/x?to=not-a-time", nil))
+		if recorder.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", recorder.Code)
+		}
+	})
+}


### PR DESCRIPTION
Groundwork for the measurement-core rework (#TBD stacks on this). Each item is independently correct and independently reviewable; none of them change how a measurement is computed.

## What was wrong, and what it meant for collected data

### 1. No `go vet`, no tests, no lint in CI

The repository had zero tests and the only CI job built and published a Docker image. Nothing stood between a change that broke the tool and a published `:latest`.

**Effect on data:** unbounded. Any regression in the measurement path would have been discovered only by noticing that the numbers looked odd.

**Fix:** a `test` job running `gofmt -l`, `go vet` and `go test -race`, with the image build gated on it.

### 2. `from`/`to` query parameters rejected real RFC3339

`shared/utils/time_parser.go` parsed with the layout `"2006-01-02T15:04:05"`. That is not RFC3339 - it has no zone offset and no fractional seconds. Every endpoint taking these parameters documents them as RFC3339 in its Swagger annotation.

**Effect on data:** anyone who followed the API documentation got a `400`, and the reason was only visible in the server's stdout via `log.Println`. Time-windowed queries were effectively unusable unless you had read the source. Silently, a window that failed to apply also means a query that returned *more* than was asked for was never possible - it just errored - so this cost time rather than correctness.

**Fix:** try `RFC3339Nano`, `RFC3339`, then the previously accepted layouts, so existing callers keep working. Errors name the offending value.

### 3. Leaked response body on every rejected submission

`HadesExecutor.Execute` placed `defer resp.Body.Close()` *after* the non-200 early return:

```go
if resp.StatusCode != http.StatusOK {
    return uuid.UUID{}, fmt.Errorf(...)   // body never closed
}
defer resp.Body.Close()
```

**Effect on data:** an unclosed body means the connection is never returned to the idle pool. This leak is on the load generator - the machine every timestamp comes from - and it compounds precisely during the long, high-rate runs the tool exists to perform. A run that starts rejecting submissions (queue full, transient 5xx) degrades its own load generator while doing so, which is exactly when you least want the instrument to drift.

**Fix:** drain and close in a `defer` placed before any return. The test asserts it exactly, via connection reuse: 30 sequential rejected submissions must open a handful of connections rather than 30.

### 4. No volume for the database

`docker-compose.yml` declared no volume, so `benchmark.db` lived in the container filesystem.

**Effect on data:** one `docker compose up --force-recreate` destroyed the dataset, with no warning and no recovery. For a tool whose entire output is that file, this is the highest-severity item in this PR.

**Fix:** `DB_PATH` is configurable and points into a named `benchmark-data` volume.

### 5. Hardcoded Traefik host

The router rule was `Host(\`ma-yu.aet.cit.tum.de\`)`, so the compose file could not be deployed to a second load generator or used by anyone outside that one machine. Now `${BENCHMARKER_HOST}`.

### 6. `build: .` next to a pinned image

Both were present, so `docker compose up` rebuilt from the working tree rather than running the pinned image. A redeploy mid-campaign could silently change the instrument without changing the recorded image tag.

**Fix:** `build: .` removed; `BENCHMARKER_IMAGE_TAG` selects the image.

## Also here

- Dockerfile: dependency-layer caching, `ca-certificates` (needed to reach systems under test over HTTPS at all), `tzdata`, and copying only the binary into the runtime image instead of the entire build context.
- `.env.example` documents the new variables.

## Verification

```
gofmt -l .        # clean
go vet ./...      # clean
go test ./...     # ok executor, ok shared/utils
```

## Review notes

Four commits, one per concern. The `persister`/`config` changes here are the minimum needed to make `DB_PATH` real; the persister is rewritten in the follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable database storage paths with persistent Docker volume support.
  - Added configurable benchmarker hostname, image version, and debug mode.
  - Expanded supported time and date query formats.

- **Bug Fixes**
  - Improved HTTP response cleanup and connection reuse after rejected submissions.
  - Enhanced invalid time-parameter responses with clearer error details.
  - Preserved acknowledged job identifiers from successful submissions.

- **Documentation**
  - Updated setup, deployment, persistence, development, and API testing instructions.

- **Chores**
  - Added automated formatting, static analysis, race testing, and build validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->